### PR TITLE
Change netcat-maint script to be started via a systemd service

### DIFF
--- a/scripts/adsbexchange-feed.service
+++ b/scripts/adsbexchange-feed.service
@@ -1,0 +1,17 @@
+
+[Unit]
+Description=adsbexchange-feed
+Wants=network.target
+After=network.target
+
+[Service]
+EnvironmentFile=/etc/default/adsbexchange
+ExecStart=/usr/local/bin/adsbexchange-feed.sh
+Type=simple
+Restart=on-failure
+RestartSec=30
+RestartPreventExitStatus=64
+SyslogIdentifier=adsbexchange-feed
+
+[Install]
+WantedBy=default.target

--- a/scripts/adsbexchange-feed.sh
+++ b/scripts/adsbexchange-feed.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+while sleep 30
+do
+	if ping -q -c 2 -W 5 feed.adsbexchange.com >/dev/null 2>&1
+	then
+		echo Connected to feed.adsbexchange.com:$RECEIVERPORT
+		/usr/bin/socat -u TCP:localhost:30005 TCP:feed.adsbexchange.com:$RECEIVERPORT
+		echo Disconnected
+	else
+		echo Unable to connect to feed.adsbexchange.com, trying again in 30 seconds!
+	fi
+done

--- a/setup.sh
+++ b/setup.sh
@@ -233,39 +233,33 @@ EOF
 
     # SETUP NETCAT TO SEND DUMP1090 DATA TO ADS-B EXCHANGE
 
-    # Create the netcat maintenance script.
-    tee adsbexchange-netcat_maint.sh > /dev/null <<EOF
-#!/bin/sh
-while true
-  do
-    sleep 30
-    #/bin/nc 127.0.0.1 30005 | /bin/nc feed.adsbexchange.com $RECEIVERPORT
-    if ping -q -c 1 -W 1 feed.adsbexchange.com >/dev/null 2>&1
-        then
-            /usr/bin/socat -u TCP:localhost:30005 TCP:feed.adsbexchange.com:$RECEIVERPORT
-    fi
-  done
+    sudo mkdir -p /usr/local/bin
+    sudo cp $PWD/scripts/adsbexchange-feed.sh /usr/local/bin
+    sudo cp $PWD/scripts/adsbexchange-feed.service /lib/systemd/system
+
+    sudo tee /etc/default/adsbexchange > /dev/null <<EOF
+RECEIVERPORT=$RECEIVERPORT
 EOF
 
     echo 76
     sleep 0.25
 
-    # Set permissions on the file adsbexchange-netcat_maint.sh.
-    chmod +x adsbexchange-netcat_maint.sh >> $LOGFILE
+    # Set permissions on the file adsbexchange-feed.sh.
+    sudo chmod +x /usr/local/bin/adsbexchange-feed.sh >> $LOGFILE
 
     echo 82
     sleep 0.25
 
-    # Add a line to execute the netcat maintenance script to /etc/rc.local so it is started after each reboot if one does not already exist.
-    if ! grep -Fxq "$PWD/adsbexchange-netcat_maint.sh &" /etc/rc.local; then
-        lnum=($(sed -n '/exit 0/=' /etc/rc.local))
-        ((lnum>0)) && sudo sed -i "${lnum[$((${#lnum[@]}-1))]}i $PWD/adsbexchange-netcat_maint.sh &\n" /etc/rc.local >> $LOGFILE
-    fi
+    # Remove old method of starting the feed script if present from rc.local
+    sudo sed -i -e '/adsbexchange-netcat_maint.sh/d' /etc/rc.local
+
+    # Enable adsbexchange-feed service
+    sudo systemctl enable adsbexchange-feed
 
     echo 88
     sleep 0.25
 
-    # Kill any currently running instances of the adsbexchange-netcat_maint.sh script.
+    # Kill the old adsbexchange-netcat_maint.sh script in case it's still running from a previous install
     PIDS=`ps -efww | grep -w "adsbexchange-netcat_maint.sh" | awk -vpid=$$ '$2 != pid { print $2 }'`
     if [ ! -z "$PIDS" ]; then
         sudo kill $PIDS >> $LOGFILE
@@ -275,10 +269,13 @@ EOF
     echo 94
     sleep 0.25
 
-    # Execute the netcat maintenance script.
-    sudo nohup $PWD/adsbexchange-netcat_maint.sh > /dev/null 2>&1 & >> $LOGFILE
     # reload systemd daemons
     sudo systemctl daemon-reload
+
+    # Start or restart adsbexchange-feed service
+    sudo systemctl restart adsbexchange-feed
+
+
     echo 100
     sleep 0.25
 


### PR DESCRIPTION
Hey James,

i've been wondering if you would be interested to change over the scripts to be started via systemd service.

Raspbian per default logs systemd service to the systemd journal, which is held in memory.
This is nice as no log rotation or anything is needed while still having the ability to check the log.
```
pi@pi ~ % sudo journalctl -fu adsbexchange-feed
-- Logs begin at Sat 2019-07-20 03:38:09 CEST. --
Jul 24 23:49:11 pi systemd[1]: adsbexchange-feed.service: Succeeded.
Jul 24 23:49:11 pi systemd[1]: Stopped adsbexchange-feed.
Jul 24 23:49:11 pi systemd[1]: Started adsbexchange-feed.
Jul 24 23:49:41 pi adsbexchange-feed[1155]: Connected to feed.adsbexchange.com:30005
```

In this PR i've only changed over the netcat maint script, but changing over MLAT as well would be easy, but wanted to ask first if you are interested.
