### PR TITLE
Add INPUT config option non-standard installations.

### DIFF
--- a/scripts/adsbexchange-feed.sh
+++ b/scripts/adsbexchange-feed.sh
@@ -4,7 +4,7 @@ do
 	if ping -q -c 2 -W 5 feed.adsbexchange.com >/dev/null 2>&1
 	then
 		echo Connected to feed.adsbexchange.com:$RECEIVERPORT
-		/usr/bin/socat -u TCP:localhost:30005 TCP:feed.adsbexchange.com:$RECEIVERPORT
+		/usr/bin/socat -u TCP:$INPUT TCP:feed.adsbexchange.com:$RECEIVERPORT
 		echo Disconnected
 	else
 		echo Unable to connect to feed.adsbexchange.com, trying again in 30 seconds!

--- a/scripts/adsbexchange-mlat.service
+++ b/scripts/adsbexchange-mlat.service
@@ -8,7 +8,7 @@ After=network.target
 EnvironmentFile=/etc/default/adsbexchange
 ExecStart=/usr/bin/mlat-client \
 	--input-type dump1090 --no-udp \
-	--input-connect localhost:30005 \
+	--input-connect $INPUT \
 	--server $MLATSERVER \
 	--user $USER \
 	--lat $RECEIVERLATITUDE \

--- a/scripts/adsbexchange-mlat.service
+++ b/scripts/adsbexchange-mlat.service
@@ -7,7 +7,7 @@ After=network.target
 [Service]
 EnvironmentFile=/etc/default/adsbexchange
 ExecStart=/usr/bin/mlat-client \
-	--input-type dump1090 --no-udp \
+	--input-type $INPUT_TYPE --no-udp \
 	--input-connect $INPUT \
 	--server $MLATSERVER \
 	--user $USER \

--- a/setup.sh
+++ b/setup.sh
@@ -235,6 +235,7 @@ fi
     RESULTS="beast,connect,localhost:30104 --results basestation,listen,31003"
     MLATSERVER="feed.adsbexchange.com:31090"
     INPUT="127.0.0.1:30005"
+    INPUT_TYPE="dump1090"
 EOF
 
     echo 76

--- a/setup.sh
+++ b/setup.sh
@@ -238,6 +238,7 @@ fi
     RECEIVERALTITUDE="$RECEIVERALTITUDE"
     RESULTS="beast,connect,localhost:30104 --results basestation,listen,31003"
     MLATSERVER="feed.adsbexchange.com:31090"
+    INPUT="127.0.0.1:30005"
 EOF
 
     echo 76

--- a/setup.sh
+++ b/setup.sh
@@ -212,10 +212,6 @@ fi
     # Enable adsbexchange-mlat service
     sudo systemctl enable adsbexchange-mlat >> $LOGFILE 2>&1
 
-    # Start or restart adsbexchange-mlat service
-    sudo systemctl restart adsbexchange-mlat >> $LOGFILE 2>&1
-
-
     echo 70
     sleep 0.25
 
@@ -275,6 +271,8 @@ EOF
     # Start or restart adsbexchange-feed service
     sudo systemctl restart adsbexchange-feed  >> $LOGFILE 2>&1
 
+    # Start or restart adsbexchange-mlat service
+    sudo systemctl restart adsbexchange-mlat >> $LOGFILE 2>&1
 
     echo 100
     sleep 0.25


### PR DESCRIPTION
For people with Radarcapes or other receivers not running on 127.0.0.1:30005.
Option is not queried in setup but rather must be changed in the
configuraton file /etc/default/adsbexchange and the services restarted.