### PR TITLE
improve space tolerance

### DIFF
--- a/scripts/adsbexchange-feed.sh
+++ b/scripts/adsbexchange-feed.sh
@@ -1,25 +1,10 @@
-#!/bin/sh
+#!/bin/bash
 
 INPUT_IP=$(echo $INPUT | cut -d: -f1)
 INPUT_PORT=$(echo $INPUT | cut -d: -f2)
 SOURCE="--net-connector $INPUT_IP,$INPUT_PORT,beast_in"
 
-while sleep 5
-do
-	if ping -q -c 2 -W 5 feed.adsbexchange.com >/dev/null 2>&1
-	then
-		echo Connected to feed.adsbexchange.com:30005
-		
-		/usr/local/share/adsbexchange/feed-adsbx --net --net-only --quiet \
-		--write-json /run/adsbexchange-feed \
-		--net-beast-reduce-interval $REDUCE_INTERVAL \
-		$TARGET $NET_OPTIONS $SOURCE
-		
-		#/usr/bin/socat -u TCP:$INPUT TCP:feed.adsbexchange.com:30005
-		
-		echo Disconnected, reconnecting in 30 seconds!
-	else
-		echo Unable to connect to feed.adsbexchange.com, trying again in 30 seconds!
-	fi
-    sleep 25
-done
+/usr/local/share/adsbexchange/feed-adsbx --net --net-only --debug=n --quiet \
+    --write-json /run/adsbexchange-feed \
+    --net-beast-reduce-interval $REDUCE_INTERVAL \
+    $TARGET $NET_OPTIONS $SOURCE

--- a/scripts/adsbexchange-mlat.service
+++ b/scripts/adsbexchange-mlat.service
@@ -7,15 +7,7 @@ After=network.target
 [Service]
 User=adsbexchange
 EnvironmentFile=/etc/default/adsbexchange
-ExecStart=/usr/local/share/adsbexchange/venv/bin/python3 /usr/local/share/adsbexchange/venv/bin/mlat-client \
-	--input-type $INPUT_TYPE --no-udp \
-	--input-connect $INPUT \
-	--server $MLATSERVER \
-	--user $USER \
-	--lat $RECEIVERLATITUDE \
-	--lon $RECEIVERLONGITUDE \
-	--alt $RECEIVERALTITUDE \
-	$RESULTS
+ExecStart=/usr/local/share/adsbexchange/adsbexchange-mlat.sh
 Type=simple
 Restart=always
 RestartSec=30

--- a/scripts/adsbexchange-mlat.sh
+++ b/scripts/adsbexchange-mlat.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+/usr/local/share/adsbexchange/venv/bin/python3 /usr/local/share/adsbexchange/venv/bin/mlat-client \
+	--input-type "$INPUT_TYPE" --no-udp \
+	--input-connect "$INPUT" \
+	--server "$MLATSERVER" \
+	--user "$USER" \
+	--lat "$RECEIVERLATITUDE" \
+	--lon "$RECEIVERLONGITUDE" \
+	--alt "$RECEIVERALTITUDE" \
+	$RESULTS

--- a/setup.sh
+++ b/setup.sh
@@ -219,7 +219,7 @@ fi
     echo "------------------------------------------------------" >> $LOGFILE
     echo "" >> $LOGFILE
 
-    NOSPACENAME="$(echo -e "${ADSBEXCHANGEUSERNAME}" | tr -dc '[a-zA-Z0-9]_\-')"
+    NOSPACENAME="$(echo -n -e "${ADSBEXCHANGEUSERNAME}" | tr -c '[a-zA-Z0-9]_\-' '_')"
 
     # Remove old method of starting the feed script if present from rc.local
     if grep -qs -e 'adsbexchange-mlat_maint.sh' /etc/rc.local; then
@@ -238,6 +238,7 @@ fi
     sleep 0.25
 
     # copy adsbexchange-mlat service file
+    cp $PWD/scripts/adsbexchange-mlat.sh $IPATH >> $LOGFILE 2>&1
     cp $PWD/scripts/adsbexchange-mlat.service /lib/systemd/system >> $LOGFILE 2>&1
 
     # Enable adsbexchange-mlat service


### PR DESCRIPTION
Change mlat-client to be started from a bash script.
This tolerates spaces in the feed / user name and in the altitude between number and unit.

Remove loop from adsbexchange-feed script, not necessary.