### PR TITLE
Use `network-online.target` instead of `network.target`

### DIFF
--- a/scripts/adsbexchange-feed.service
+++ b/scripts/adsbexchange-feed.service
@@ -1,8 +1,7 @@
-
 [Unit]
 Description=adsbexchange-feed
-Wants=network.target
-After=network.target
+Wants=network-online.target
+After=network-online.target
 
 [Service]
 User=adsbexchange

--- a/scripts/adsbexchange-mlat.service
+++ b/scripts/adsbexchange-mlat.service
@@ -1,8 +1,7 @@
-
 [Unit]
 Description=adsbexchange-mlat
-Wants=network.target
-After=network.target
+Wants=network-online.target
+After=network-online.target
 
 [Service]
 User=adsbexchange


### PR DESCRIPTION
> * `network.target` has very little meaning during start-up. It only indicates that the network management stack is up after it has been reached. Whether any network interfaces are already configured when it is reached is undefined. Its primary purpose is for ordering things properly at shutdown.
> * `network-online.target` is a target that actively waits until the nework is "up", where the definition of "up" is defined by the network management software.

> If you need to delay you service after the network is up, include
> ```
> After=network-online.target
> Wants=network-online.target
> ```
> in the .service file. This will ensure that all configured network devices are up and have an IP address assigned before the service is started.

https://www.freedesktop.org/wiki/Software/systemd/NetworkTarget/